### PR TITLE
Handle default replication identity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pypgoutput",
-    version="0.0.2",
+    version="0.0.3",
     author="Daniel Geals",
     author_email="danielgeals@gmail.com",
     description="PostgreSQL CDC library using pgoutput and python",

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -67,7 +67,7 @@ def configure_test_db(
         id integer primary key,
         json_data jsonb,
         amount numeric(10, 2),
-        updated_at timestamptz
+        updated_at timestamptz not null
     );"""
     cursor.execute(query)
     yield cdc_reader
@@ -120,7 +120,7 @@ def test_001_insert(
     assert message.table_schema.column_definitions[3].name == "updated_at"
     assert message.table_schema.column_definitions[3].part_of_pkey == 0
     assert message.table_schema.column_definitions[3].type_name == "timestamp with time zone"
-    assert message.table_schema.column_definitions[3].optional is True
+    assert message.table_schema.column_definitions[3].optional is False
 
     query = "SELECT oid, typname FROM pg_type WHERE oid = %s::oid;"
     cursor.execute(query, vars=(message.table_schema.column_definitions[0].type_id,))
@@ -185,7 +185,7 @@ def test_002_update(
     assert message.table_schema.column_definitions[3].name == "updated_at"
     assert message.table_schema.column_definitions[3].part_of_pkey == 0
     assert message.table_schema.column_definitions[3].type_name == "timestamp with time zone"
-    assert message.table_schema.column_definitions[3].optional is True
+    assert message.table_schema.column_definitions[3].optional is False
     # TODO check what happens with replica identity full?
     assert message.before is None
     assert message.after is not None
@@ -228,13 +228,9 @@ def test_003_delete(
     assert message.table_schema.column_definitions[3].name == "updated_at"
     assert message.table_schema.column_definitions[3].part_of_pkey == 0
     assert message.table_schema.column_definitions[3].type_name == "timestamp with time zone"
-    assert message.table_schema.column_definitions[3].optional is True
+    assert message.table_schema.column_definitions[3].optional is False
     assert message.before is not None
     assert message.before["id"] == 10
-    # TODO: check and test what happens with replica identity
-    assert message.before["json_data"] is None
-    assert message.before["amount"] is None
-    assert message.before["updated_at"] is None
     assert message.after is None
 
 
@@ -272,7 +268,7 @@ def test_004_truncate(
     assert message.table_schema.column_definitions[3].name == "updated_at"
     assert message.table_schema.column_definitions[3].part_of_pkey == 0
     assert message.table_schema.column_definitions[3].type_name == "timestamp with time zone"
-    assert message.table_schema.column_definitions[3].optional is True
+    assert message.table_schema.column_definitions[3].optional is False
     assert message.before is None
     assert message.after is None
 


### PR DESCRIPTION
Applying pydantic schema (containing all columns of relation) to update/delete messages using default replica identity setting caused the following errors:

```
Error extracting LR logs: Error creating ChangeEvent: 1 validation error for DynamicSchemaModel_16774
updated_at
  none is not an allowed value (type=type_error.none.not_allowed)

```
https://www.postgresql.org/docs/12/protocol-logicalrep-message-formats.html

For update this PR handles the following option
```
Byte1('K')

    Identifies the following TupleData submessage as a key. This field is optional and is only present if the update changed data in any of the column(s) that are part of the REPLICA IDENTITY index.

```
For delete this PR handles the following option
```
Byte1('K')

    Identifies the following TupleData submessage as a key. This field is present if the table in which the delete has happened uses an index as REPLICA IDENTITY.

```

